### PR TITLE
Fixed issue #45: inconsistent TabularInput keys

### DIFF
--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -43,22 +43,23 @@ class CsvOutput(FileOutput):
             if to_csv.keys() != self._fieldnames:
                 # Get data from current csv
                 with open(self._file_name, 'r') as f:
+                    # Save current csv in list of dicts
                     reader = csv.DictReader(f)
+                    oldData = []
+                    for row in reader:
+                        oldData.append(row)
 
                     # Add new fields to self._fieldnames
                     for key in to_csv.keys():
                         if key not in self._fieldnames:
                             self._fieldnames.add(key)
                     
-                    # Write back to csv with new fieldnames
-                    self._writer = csv.DictWriter(
-                        self._log_file,
-                        fieldnames=self._fieldnames,
-                        extrasaction='raise')
-
+                    # Write back new header & old data to csv
+                    self._writer.fieldnames = self._fieldnames
                     self._log_file.seek(0)
                     self._writer.writeheader()
-                    self._writer.writerows(reader)
+                    for row in oldData:
+                        self._writer.writerow(row)
 
             self._writer.writerow(to_csv)
 

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -17,8 +17,6 @@ class CsvOutput(FileOutput):
         super().__init__(file_name)
         self._writer = None
         self._fieldnames = None
-        self._warned_once = set()
-        self._disable_warnings = False
         self._file_name = file_name
 
     @property
@@ -69,24 +67,3 @@ class CsvOutput(FileOutput):
         else:
             raise ValueError('Unacceptable type.')
 
-    def _warn(self, msg):
-        """Warns the user using warnings.warn.
-
-        The stacklevel parameter needs to be 3 to ensure the call to logger.log
-        is the one printed.
-        """
-        if not self._disable_warnings and msg not in self._warned_once:
-            warnings.warn(
-                colorize(msg, 'yellow'), CsvOutputWarning, stacklevel=3)
-        self._warned_once.add(msg)
-        return msg
-
-    def disable_warnings(self):
-        """Disable logger warnings for testing."""
-        self._disable_warnings = True
-
-
-class CsvOutputWarning(UserWarning):
-    """Warning class for CsvOutput."""
-
-    pass

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -54,7 +54,7 @@ class TestCsvOutput:
         self.csv_output.dump()
 
         correct = [
-            {'foo': str(foo)},
+            {'foo': str(foo), 'bar': ''},
             {'foo': str(foo * 2), 'bar': str(bar * 2)},
         ]
         self.assert_csv_matches(correct)
@@ -69,7 +69,7 @@ class TestCsvOutput:
         self.csv_output.record(self.tabular)
 
         self.tabular.record('foo', foo)
-        
+
         with pytest.warns(CsvOutputWarning):
             self.csv_output.record(self.tabular)
 
@@ -80,7 +80,7 @@ class TestCsvOutput:
 
         correct = [
             {'foo': str(foo), 'bar': str(bar * 2)},
-            {'foo': str(foo * 2)},
+            {'foo': str(foo * 2), 'bar': ''},
         ]
         self.assert_csv_matches(correct)
 

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -35,11 +35,13 @@ class TestCsvOutput:
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
-    def test_record_inconsistent(self):
+    def test_record_inconsistent_expand(self):
+        # Test for increase in columns
         foo = 1
         bar = 10
         self.tabular.record('foo', foo)
         self.csv_output.record(self.tabular)
+
         self.tabular.record('foo', foo * 2)
         self.tabular.record('bar', bar * 2)
 
@@ -53,8 +55,33 @@ class TestCsvOutput:
 
         correct = [
             {'foo': str(foo)},
+            {'foo': str(foo * 2), 'bar': str(bar * 2)},
+        ]
+        self.assert_csv_matches(correct)
+
+    def test_record_inconsistent_shrink(self):
+        # Test for decrease in columns
+        foo = 1
+        bar = 10
+
+        self.tabular.record('foo', foo * 2)
+        self.tabular.record('bar', bar * 2)
+        self.csv_output.record(self.tabular)
+
+        self.tabular.record('foo', foo)
+        
+        with pytest.warns(CsvOutputWarning):
+            self.csv_output.record(self.tabular)
+
+        # this should not produce a warning, because we only warn once
+        self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        correct = [
+            {'foo': str(foo), 'bar': str(bar * 2)},
             {'foo': str(foo * 2)},
-        ]  # yapf: disable
+        ]
         self.assert_csv_matches(correct)
 
     def test_empty_record(self):

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -44,11 +44,6 @@ class TestCsvOutput:
 
         self.tabular.record('foo', foo * 2)
         self.tabular.record('bar', bar * 2)
-
-        with pytest.warns(CsvOutputWarning):
-            self.csv_output.record(self.tabular)
-
-        # this should not produce a warning, because we only warn once
         self.csv_output.record(self.tabular)
 
         self.csv_output.dump()
@@ -69,11 +64,6 @@ class TestCsvOutput:
         self.csv_output.record(self.tabular)
 
         self.tabular.record('foo', foo)
-
-        with pytest.warns(CsvOutputWarning):
-            self.csv_output.record(self.tabular)
-
-        # this should not produce a warning, because we only warn once
         self.csv_output.record(self.tabular)
 
         self.csv_output.dump()


### PR DESCRIPTION
To solve this issue, when the recorded keys are not identical to the current csv's keys, I save the existing csv's data. Then I overwrite the csv file with a new header, fill it in with previous data, and add the new data.

This will have a long runtime if the csv files are extremely long. An alternative I considered was to manually change the csv header and append the new data rows to it, but this solution was a little more hassle-free, so I went with this instead.

For the tests, I tested the scenario of recording an input with new keys, then a separate scenario of recording an input that lacks some keys.